### PR TITLE
Add Node.js API request playground

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+API_KEY=your_api_key
+API_URL=https://api.example.com/v1/chat
+MODEL=model-name
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # habr-demo-ai-api
-Test playground for AI API requests
+
+This is a simple Node.js playground for sending requests to various AI providers.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your API parameters:
+
+```bash
+cp .env.example .env
+# edit .env with your API_KEY, API_URL and MODEL
+```
+
+2. Install dependencies:
+
+```bash
+npm install
+```
+
+3. Run the script:
+
+```bash
+npm start
+```
+
+The request will use the messages defined in `src/index.js` and print the assistant's reply to the console.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "habr-demo-ai-api",
+  "version": "1.0.0",
+  "description": "Test playground for AI API requests",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node src/index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "node-fetch": "^2.6.12",
+    "dotenv": "^16.3.1"
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,47 @@
+import fetch from 'node-fetch';
+import 'dotenv/config';
+
+const { API_KEY, API_URL, MODEL } = process.env;
+
+if (!API_KEY || !API_URL || !MODEL) {
+  console.error('Missing API configuration. Please set API_KEY, API_URL, and MODEL in .env file.');
+  process.exit(1);
+}
+
+const messages = [
+  { role: 'user', content: 'Привет!' },
+  { role: 'assistant', content: 'Привет! Чем могу помочь?' },
+  { role: 'user', content: 'Расскажи мне о себе.' }
+];
+
+const body = {
+  model: MODEL,
+  messages,
+  temperature: 0.7
+};
+
+const headers = {
+  'Content-Type': 'application/json',
+  'Authorization': `Bearer ${API_KEY}`
+};
+
+async function main() {
+  try {
+    const response = await fetch(API_URL, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body)
+    });
+
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+
+    const data = await response.json();
+    console.log(data.choices?.[0]?.message?.content);
+  } catch (error) {
+    console.error('Error sending request:', error.message);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add Node app for experimenting with AI providers
- document setup instructions
- provide example `.env` file
- ignore runtime files

## Testing
- `npm test` *(fails: no test specified)*
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687f18d514a8832d96dba56e315a90db