### PR TITLE
Add environment variable examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,36 @@ npm start
 ```
 
 The request will use the messages defined in `src/index.js` and print the assistant's reply to the console.
+
+## Environment variables
+
+Create a `.env` file with at least three parameters:
+
+```bash
+API_KEY=your_api_key
+API_URL=https://api.openai.com/v1/chat/completions
+MODEL=gpt-4
+```
+
+### API URLs
+
+Some common API endpoints compatible with the OpenAI format:
+
+| Provider  | Example URL                                       |
+|-----------|---------------------------------------------------|
+| OpenAI    | `https://api.openai.com/v1/chat/completions`      |
+| DeepSeek  | `https://api.deepseek.com/v1/chat/completions`    |
+| OpenRouter| `https://openrouter.ai/api/v1/chat/completions`   |
+
+### Modern models
+
+Specify the desired `MODEL` name. Below are a few current options:
+
+* `gpt-4o`
+* `gpt-4-turbo`
+* `gpt-4`
+* `gpt-3.5-turbo-1106`
+* `gpt-3.5-turbo`
+* `deepseek-chat`
+
+Use the URL and model that match your API provider.


### PR DESCRIPTION
## Summary
- add a section describing `.env` variable examples
- list URLs for a few OpenAI‑compatible services
- include common modern model names

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687f2e9e9354832d90f2d9c20f31a3f3